### PR TITLE
fix: Force amd64 platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
   geth-client:
     # geth execution node client, used to connect to other geth nodes (i.e., our PoA node)
     container_name: geth-client-cnt
+    platform: linux/amd64
     build:
       context: ./geth
       dockerfile: ./Containerfile


### PR DESCRIPTION
On ARM64 machines (i.e., M-Macs) the build fails due to a fixed amd64 Go binary. Setting the platform explicitly avoids a build failure as long as platform emulation works, thus the README instructions should work on ARM64 machines without any change.